### PR TITLE
bump min spin version to v2.3.1

### DIFF
--- a/contrib/spin-plugin.json.tmpl
+++ b/contrib/spin-plugin.json.tmpl
@@ -3,7 +3,7 @@
   "description": "A plugin to manage spin apps",
   "homepage": "https://github.com/spinkube/spin-plugin-kube",
   "version": "{{ Version }}",
-  "spinCompatibility": ">=1.5",
+  "spinCompatibility": ">=2.3.1",
   "license": "Apache-2.0",
   "packages": [
     {

--- a/spin-pluginify.toml
+++ b/spin-pluginify.toml
@@ -1,7 +1,7 @@
 name = "kube"
 description = "Commands for publishing applications to Kubernetes using the spin-operator."
 version = "0.1.0"
-spin_compatibility = ">=2.0"
+spin_compatibility = ">=2.3.1"
 license = "Apache-2.0"
 homepage = "https://github.com/spinkube/spin-plugin-kube"
 package = "./bin/spin-kube"


### PR DESCRIPTION
v2.3.1 of spin has a fix for OCI images push.