### PR TITLE
fix: fetch full-depth

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: stable
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,17 +14,18 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        # fetch all history for goreleaser to work correctly
+        # https://goreleaser.com/ci/actions/#workflow
+        fetch-depth: 0
 
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: "1.22.x"
+        go-version: stable
 
-    - name: Install dependencies
-      run: go mod download
-
-    - name: GoReleaser
-      uses: goreleaser/goreleaser-action@v5.0.0
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v5
       with:
         version: latest
         args: release --clean ${{ github.ref == 'refs/heads/main' && '--snapshot' || '' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: "1.22.x"
+        go-version: stable
 
     - name: Build
       run: go build -o spin-plugin-kube main.go


### PR DESCRIPTION
This is required for GoReleaser to work properly. Without that, GoReleaser might fail or behave incorrectly.

For example, in our case it was unable to generate a proper changelog for v0.1.1.