### PR TITLE
update template file to use correct version

### DIFF
--- a/contrib/spin-plugin.json.tmpl
+++ b/contrib/spin-plugin.json.tmpl
@@ -9,27 +9,32 @@
     {
       "os": "linux",
       "arch": "amd64",
-      {{#addURLAndSha}}https://github.com/spinkube/spin-plugin-kube/releases/download/{{ TagName }}/spin-plugin-kube-{{ TagName }}-linux-amd64.tar.gz{{/addURLAndSha}}
+      {{#addURLAndSha}}https://github.com/spinkube/spin-plugin-kube/releases/download/{{ TagName }}/spin-plugin-kube-{{ Version }}-linux-amd64.tar.gz{{/addURLAndSha}}
     },
     {
       "os": "linux",
       "arch": "aarch64",
-      {{#addURLAndSha}}https://github.com/spinkube/spin-plugin-kube/releases/download/{{ TagName }}/spin-plugin-kube-{{ TagName }}-linux-arm64.tar.gz{{/addURLAndSha}}
+      {{#addURLAndSha}}https://github.com/spinkube/spin-plugin-kube/releases/download/{{ TagName }}/spin-plugin-kube-{{ Version }}-linux-arm64.tar.gz{{/addURLAndSha}}
     },
     {
       "os": "macos",
       "arch": "aarch64",
-      {{#addURLAndSha}}https://github.com/spinkube/spin-plugin-kube/releases/download/{{ TagName }}/spin-plugin-kube-{{ TagName }}-darwin-arm64.tar.gz{{/addURLAndSha}}
+      {{#addURLAndSha}}https://github.com/spinkube/spin-plugin-kube/releases/download/{{ TagName }}/spin-plugin-kube-{{ Version }}-darwin-arm64.tar.gz{{/addURLAndSha}}
     },
     {
       "os": "macos",
       "arch": "amd64",
-      {{#addURLAndSha}}https://github.com/spinkube/spin-plugin-kube/releases/download/{{ TagName }}/spin-plugin-kube-{{ TagName }}-darwin-amd64.tar.gz{{/addURLAndSha}}
+      {{#addURLAndSha}}https://github.com/spinkube/spin-plugin-kube/releases/download/{{ TagName }}/spin-plugin-kube-{{ Version }}-darwin-amd64.tar.gz{{/addURLAndSha}}
     },
     {
       "os": "windows",
       "arch": "amd64",
-      {{#addURLAndSha}}https://github.com/spinkube/spin-plugin-kube/releases/download/{{ TagName }}/spin-plugin-kube-{{ TagName }}-windows-amd64.tar.gz{{/addURLAndSha}}
+      {{#addURLAndSha}}https://github.com/spinkube/spin-plugin-kube/releases/download/{{ TagName }}/spin-plugin-kube-{{ Version }}-windows-amd64.tar.gz{{/addURLAndSha}}
+    },
+    {
+      "os": "windows",
+      "arch": "aarch64",
+      {{#addURLAndSha}}https://github.com/spinkube/spin-plugin-kube/releases/download/{{ TagName }}/spin-plugin-kube-{{ Version }}-windows-arm64.tar.gz{{/addURLAndSha}}
     }
   ]
 }


### PR DESCRIPTION
TagName is v0.1.0
Version is 0.1.0 (without the prefix `v`)