### PR TITLE
feat(scaffold): add support for variables

### DIFF
--- a/pkg/cmd/scaffold_test.go
+++ b/pkg/cmd/scaffold_test.go
@@ -85,6 +85,19 @@ func TestScaffoldOutput(t *testing.T) {
 			},
 			expected: "keda_autoscaler.yml",
 		},
+		{
+			name: "variables are provided",
+			opts: ScaffoldOptions{
+				from:     "ghcr.io/foo/example-app:v0.1.0",
+				replicas: 2,
+				executor: "containerd-shim-spin",
+				variables: map[string]string{
+					"bar": "yee",
+					"foo": "yoo",
+				},
+			},
+			expected: "variables.yml",
+		},
 	}
 
 	for _, tc := range testcases {

--- a/pkg/cmd/testdata/variables.yml
+++ b/pkg/cmd/testdata/variables.yml
@@ -1,0 +1,13 @@
+apiVersion: core.spinoperator.dev/v1alpha1
+kind: SpinApp
+metadata:
+  name: example-app
+spec:
+  image: "ghcr.io/foo/example-app:v0.1.0"
+  executor: containerd-shim-spin
+  replicas: 2
+  variables:
+  - name: bar
+    value: yee
+  - name: foo
+    value: yoo


### PR DESCRIPTION
fixes #31 

### Try it out
1. Set up a SpinKube [cluster](https://www.spinkube.dev/docs/install/quickstart/)
2. Apply an example app, supplying that required foo and bar variables using the new flag

```sh
go run main.go scaffold --from http://ghcr.io/kate-goldenring/spin-foo-bar-variables:v1 --variable foo=yoo --variable bar=yee --replicas 1 | kubectl apply -f -
```

3. Port forward the k8s svc and curl the endpoint to see the variable values logged